### PR TITLE
add go to summary slide hotspot button in answer hotspot picker

### DIFF
--- a/language/en.json
+++ b/language/en.json
@@ -38,6 +38,7 @@
     "answerHotspot": "Answer hotspots",
     "answerHotspotTrue": "Correct answer",
     "answerHotspotFalse": "Incorrect answer",
+    "goToSummarySlide": "Go to summary slide hotspot",
     "expandBreadcrumbButtonLabel": "Go back",
     "collapseBreadcrumbButtonLabel": "Close navigation",
     "aspectRatioPortrait": "Portrait",

--- a/library.json
+++ b/library.json
@@ -2,7 +2,7 @@
   "title": "Interaktiv Tavle Editor",
   "majorVersion": 1,
   "minorVersion": 24,
-  "patchVersion": 3,
+  "patchVersion": 4,
   "runnable": 0,
   "machineName": "H5PEditor.InteraktivTavle",
   "author": "Joubel",

--- a/scripts/active-surface-mode-utils.js
+++ b/scripts/active-surface-mode-utils.js
@@ -11,12 +11,12 @@ export function createActiveSurfaceModeAnswerButtons() {
     buttons: [
       createTransparentHotspotButton("yes-button", "true"),
       createTransparentHotspotButton("no-button", "false"),
+      createGoToSummaryPageHotspotButton(),
     ],
   };
 }
 
 /**
- *
  * @param {string} id
  * @param {"true" | "false"} answerType
  */
@@ -29,6 +29,18 @@ function createTransparentHotspotButton(id, answerType) {
       ...hotspotParams,
       answerType,
       goToSlideType: "none",
+    },
+  };
+}
+
+function createGoToSummaryPageHotspotButton() {
+  return {
+    id: "summary-page-button",
+    // @ts-expect-error H5PEditor is globally available
+    title: H5PEditor.t('H5PEditor.InteraktivTavle', `goToSummarySlide`),
+    params: {
+      ...hotspotParams,
+      goToSlideType: "go-to-summary-slide",
     },
   };
 }

--- a/styles/toolbar.css
+++ b/styles/toolbar.css
@@ -171,7 +171,8 @@
 .h5p-dragnbar-shape-arrows-alt-h-button::before,
 .h5p-dragnbar-shape-arrows-alt-v-button::before,
 .h5p-dragnbar-shape-arrows-alt-button::before,
-.h5p-dragnbar-shape-thumbs-up-button::before
+.h5p-dragnbar-shape-thumbs-up-button::before,
+.h5p-dragnbar-summary-page-button-button::before
  {
   font-family: 'H5PFontAwesome4';
   color: #494949;
@@ -328,6 +329,9 @@
 }
 .h5p-dragnbar-no-button-button::before {
   content: "\e92a";
+} 
+.h5p-dragnbar-summary-page-button-button::before {
+  content: "\f005";
 }
 
 .h5p-dragnbar-li-ul {


### PR DESCRIPTION
This button creates a regular hotspot that has the "Go to summary slide" option set.
The "Go to summary slide" option makes the hotspot point to the last slide,
which will be the summary slide if it exists.

Depends on https://github.com/NDLANO/h5p-course-presentation/pull/59